### PR TITLE
chore: Phase 1 ops readiness — slog, version, Makefile, systemd, Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vpnctl
+*.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.22-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN make build
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wireguard-tools iproute2 ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/vpnctl /usr/local/bin/vpnctl
+ENTRYPOINT ["vpnctl"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILD   ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS  = -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildTime=$(BUILD)
+
+.PHONY: build test clean docker
+
+build:
+	go build -ldflags "$(LDFLAGS)" -o vpnctl ./cmd/vpnctl
+
+test:
+	go test ./...
+
+clean:
+	rm -f vpnctl
+
+docker:
+	docker build -t vpnctl:$(VERSION) .

--- a/README.md
+++ b/README.md
@@ -167,6 +167,46 @@ Requires vpnctl echo responder on target peers (`vpnctl monitor`, `vpnctl node s
 - `wg` and `ip` commands available
 - Go 1.22+ to build
 
+## Installation
+
+### From source
+
+```bash
+git clone https://github.com/timo-kang/vpnctl.git
+cd vpnctl
+make build
+sudo cp vpnctl /usr/local/bin/
+```
+
+### With Docker
+
+```bash
+make docker
+docker run -p 8443:8443 -v vpnctl-data:/var/lib/vpnctl vpnctl controller init --config /etc/vpnctl/config.yaml
+```
+
+### systemd
+
+```bash
+sudo cp vpnctl /usr/local/bin/
+sudo mkdir -p /etc/vpnctl
+sudo cp deploy/vpnctl-node.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now vpnctl-node
+```
+
+## Logging
+
+vpnctl uses structured logging via Go's `log/slog`.
+
+```bash
+# Set log level (debug, info, warn, error)
+VPNCTL_LOG_LEVEL=debug vpnctl node serve --config node.yaml
+
+# JSON output (for log aggregation)
+VPNCTL_LOG_FORMAT=json vpnctl node serve --config node.yaml
+```
+
 ## License
 
 Apache License 2.0. See [LICENSE](LICENSE).

--- a/cmd/vpnctl/main.go
+++ b/cmd/vpnctl/main.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -70,7 +71,34 @@ Planned:
  vpnctl node add
 `
 
+func setupLogging() {
+	logLevel := os.Getenv("VPNCTL_LOG_LEVEL")
+	logFormat := os.Getenv("VPNCTL_LOG_FORMAT")
+
+	var level slog.Level
+	switch strings.ToLower(logLevel) {
+	case "debug":
+		level = slog.LevelDebug
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo
+	}
+
+	opts := &slog.HandlerOptions{Level: level}
+	var handler slog.Handler
+	if strings.ToLower(logFormat) == "json" {
+		handler = slog.NewJSONHandler(os.Stderr, opts)
+	} else {
+		handler = slog.NewTextHandler(os.Stderr, opts)
+	}
+	slog.SetDefault(slog.New(handler))
+}
+
 func main() {
+	setupLogging()
 	if len(os.Args) < 2 {
 		fmt.Fprint(os.Stderr, usage)
 		os.Exit(2)

--- a/cmd/vpnctl/main.go
+++ b/cmd/vpnctl/main.go
@@ -35,9 +35,16 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+var (
+	version   = "dev"
+	commit    = "unknown"
+	buildTime = "unknown"
+)
+
 const usage = `vpnctl - minimal VPN control-plane + metrics (MVP)
 
 Usage:
+  vpnctl version
   vpnctl controller init --config <path>
   vpnctl controller status --config <path>
   vpnctl node join --config <path>
@@ -73,6 +80,8 @@ func main() {
 	switch cmd {
 	case "-h", "--help", "help":
 		fmt.Print(usage)
+	case "version", "--version":
+		fmt.Printf("vpnctl %s (commit %s, built %s)\n", version, commit, buildTime)
 	case "controller":
 		handleController(os.Args[2:])
 	case "node":

--- a/cmd/vpnctl/main.go
+++ b/cmd/vpnctl/main.go
@@ -1626,7 +1626,7 @@ func fatal(err error) {
 	if err == nil {
 		return
 	}
-	fmt.Fprintln(os.Stderr, err)
+	slog.Error("fatal", "err", err)
 	os.Exit(1)
 }
 
@@ -1865,6 +1865,8 @@ func handleMonitor(args []string) {
 			}
 		}
 	} else {
+		// Suppress slog output during TUI mode to avoid corrupting the display.
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 		sub := mon.Subscribe()
 		go mon.Run(ctx)
 		tuiModel := monitor.NewTUIModel(*iface, sub)

--- a/deploy/vpnctl-controller.service
+++ b/deploy/vpnctl-controller.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=vpnctl controller
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/vpnctl controller init --config /etc/vpnctl/controller.yaml
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/vpnctl-controller.service
+++ b/deploy/vpnctl-controller.service
@@ -8,6 +8,7 @@ Type=simple
 ExecStart=/usr/local/bin/vpnctl controller init --config /etc/vpnctl/controller.yaml
 Restart=on-failure
 RestartSec=5
+AmbientCapabilities=CAP_NET_ADMIN
 LimitNOFILE=65536
 
 [Install]

--- a/deploy/vpnctl-node.service
+++ b/deploy/vpnctl-node.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=vpnctl node agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/vpnctl node serve --config /etc/vpnctl/node.yaml
+Restart=on-failure
+RestartSec=5
+AmbientCapabilities=CAP_NET_ADMIN
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,7 +6,7 @@ package agent
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/netip"
 	"strings"
 	"time"
@@ -40,7 +40,7 @@ func Run(ctx context.Context, cfg config.NodeConfig) error {
 			return err
 		}
 		defer shared.Close()
-		log.Printf("probe responder on %s", shared.LocalAddr())
+		slog.Info("probe responder started", "addr", shared.LocalAddr())
 	}
 
 	keepaliveTicker := time.NewTicker(time.Duration(cfg.KeepaliveIntervalSec) * time.Second)
@@ -57,7 +57,7 @@ func Run(ctx context.Context, cfg config.NodeConfig) error {
 	var natType string
 	activePeers := map[string]wireguard.Peer{}
 	if err := fillServerConfig(ctx, client, &cfg); err != nil {
-		log.Printf("server config fetch failed: %v", err)
+		slog.Warn("server config fetch failed", "err", err)
 	}
 
 	// Health check ticker — detect dead tunnels.
@@ -69,11 +69,9 @@ func Run(ctx context.Context, cfg config.NodeConfig) error {
 		healthTicker := time.NewTicker(time.Duration(cfg.HealthCheckIntervalSec) * time.Second)
 		defer healthTicker.Stop()
 		healthC = healthTicker.C
-		log.Printf("health check enabled interval=%ds failures=%d timeout=%ds hub=%s",
-			cfg.HealthCheckIntervalSec, cfg.HealthCheckFailures, cfg.HealthCheckTimeoutSec, hubProbeAddr)
+		slog.Info("health check enabled", "interval_sec", cfg.HealthCheckIntervalSec, "failures", cfg.HealthCheckFailures, "timeout_sec", cfg.HealthCheckTimeoutSec, "hub", hubProbeAddr)
 	} else if cfg.HealthCheckIntervalSec > 0 && cfg.HealthCheckFailures > 0 {
-		log.Printf("health check configured but probe address could not be determined (server_allowed_ips=%v server_probe_port=%d)",
-			cfg.ServerAllowedIPs, cfg.ServerProbePort)
+		slog.Warn("health check probe address undetermined", "server_allowed_ips", cfg.ServerAllowedIPs, "server_probe_port", cfg.ServerProbePort)
 	}
 	healthFailures := 0
 
@@ -84,7 +82,7 @@ func Run(ctx context.Context, cfg config.NodeConfig) error {
 		case <-keepaliveTicker.C:
 			_, _, err := register(ctx, client, cfg)
 			if err != nil {
-				log.Printf("keepalive register failed: %v", err)
+				slog.Warn("keepalive register failed", "err", err)
 			}
 		case <-stunTicker.C:
 			if cfg.DirectMode == "off" || len(cfg.STUNServers) == 0 {
@@ -95,7 +93,7 @@ func Run(ctx context.Context, cfg config.NodeConfig) error {
 			}
 			addr, nat, err := probeShared(ctx, shared, cfg.STUNServers, 5*time.Second)
 			if err != nil {
-				log.Printf("STUN probe failed: %v", err)
+				slog.Warn("STUN probe failed", "err", err)
 				break
 			}
 			publicAddr = addr
@@ -105,12 +103,12 @@ func Run(ctx context.Context, cfg config.NodeConfig) error {
 				NATType:    natType,
 				PublicAddr: publicAddr,
 			}); err != nil {
-				log.Printf("NAT probe submit failed: %v", err)
+				slog.Warn("NAT probe submit failed", "err", err)
 			}
 		case <-candidatesTicker.C:
 			resp, err := client.Candidates(ctx, nodeID)
 			if err != nil {
-				log.Printf("candidates fetch failed: %v", err)
+				slog.Warn("candidates fetch failed", "err", err)
 				break
 			}
 			candidates = resp.Peers
@@ -130,7 +128,7 @@ func Run(ctx context.Context, cfg config.NodeConfig) error {
 					if prev, ok := allowedOwner[allowedIP]; ok && prev != peer.ID {
 						// Overlapping AllowedIPs are invalid in WireGuard. Skip duplicates so one bad/stale
 						// registry entry doesn't block all peer injection.
-						log.Printf("skip peer injection name=%s id=%s vpn_ip=%s: duplicate allowed_ip (already owned by %s)", peer.Name, peer.ID, peer.VPNIP, prev)
+						slog.Warn("skip peer injection: duplicate allowed_ip", "name", peer.Name, "id", peer.ID, "vpn_ip", peer.VPNIP, "owner", prev)
 						inject = false
 					} else {
 						allowedOwner[allowedIP] = peer.ID
@@ -193,22 +191,22 @@ func Run(ctx context.Context, cfg config.NodeConfig) error {
 
 				if cfg.MetricsPath != "" {
 					if err := metrics.AppendCSV(cfg.MetricsPath, []model.Metric{sample}); err != nil {
-						log.Printf("append metrics failed: %v", err)
+						slog.Warn("append metrics failed", "err", err)
 					}
 				}
 				if err := client.SubmitMetrics(ctx, api.MetricsRequest{NodeID: nodeID, Samples: []model.Metric{sample}}); err != nil {
-					log.Printf("submit metrics failed: %v", err)
+					slog.Warn("submit metrics failed", "err", err)
 				}
 			}
 
 			if cfg.ServerPublicKey != "" && cfg.ServerEndpoint != "" && len(cfg.ServerAllowedIPs) > 0 {
 				if !peersEqual(activePeers, desired) {
 					peerList := peersFromMap(desired)
-					log.Printf("inject wg peers count=%d", len(peerList))
+					slog.Info("injecting wg peers", "count", len(peerList))
 					if err := wireguard.ApplyPeers(cfg, peerList); err != nil {
-						log.Printf("apply peers failed: %v", err)
+						slog.Error("apply peers failed", "err", err)
 					} else {
-						log.Printf("inject wg peers ok count=%d", len(peerList))
+						slog.Info("wg peers injected", "count", len(peerList))
 						activePeers = desired
 					}
 				}
@@ -224,14 +222,14 @@ func Run(ctx context.Context, cfg config.NodeConfig) error {
 					return ctx.Err()
 				}
 				// Infrastructure error (local socket, etc.) — don't count as tunnel failure.
-				log.Printf("health check error (not counted) hub=%s: %v", hubProbeAddr, hErr)
+				slog.Warn("health check error (not counted)", "hub", hubProbeAddr, "err", hErr)
 				break
 			}
 			if ok {
 				healthFailures = 0
 			} else {
 				healthFailures++
-				log.Printf("health check failed (%d/%d) hub=%s", healthFailures, cfg.HealthCheckFailures, hubProbeAddr)
+				slog.Warn("health check failed", "failures", healthFailures, "threshold", cfg.HealthCheckFailures, "hub", hubProbeAddr)
 				if healthFailures >= cfg.HealthCheckFailures {
 					return ErrTunnelDead
 				}

--- a/internal/controller/server.go
+++ b/internal/controller/server.go
@@ -6,7 +6,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/netip"
 	"os"
@@ -80,7 +80,7 @@ func (s *Server) ListenAndServe() error {
 		if err != nil {
 			return fmt.Errorf("probe responder: %w", err)
 		}
-		log.Printf("probe responder listening on %s", addr)
+		slog.Info("probe responder listening", "addr", addr)
 	}
 
 	mux := http.NewServeMux()
@@ -99,7 +99,7 @@ func (s *Server) ListenAndServe() error {
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	log.Printf("controller listening on %s", s.cfg.Listen)
+	slog.Info("controller listening", "addr", s.cfg.Listen)
 	return server.ListenAndServe()
 }
 
@@ -344,7 +344,7 @@ func (s *Server) handleDirectResult(w http.ResponseWriter, r *http.Request) {
 		s.mu.Unlock()
 	}
 
-	log.Printf("direct result node=%s peer=%s success=%v rtt_ms=%.2f reason=%s", req.NodeID, req.PeerID, req.Success, req.RTTMs, req.Reason)
+	slog.Debug("direct result", "node", req.NodeID, "peer", req.PeerID, "success", req.Success, "rtt_ms", req.RTTMs, "reason", req.Reason)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -354,8 +354,7 @@ func (s *Server) handleWGConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.cfg.ServerPublicKey == "" || s.cfg.ServerEndpoint == "" || len(s.cfg.ServerAllowedIPs) == 0 {
-		log.Printf("wg-config error: server config not set (public_key=%t endpoint=%t allowed_ips=%d)",
-			s.cfg.ServerPublicKey != "", s.cfg.ServerEndpoint != "", len(s.cfg.ServerAllowedIPs))
+		slog.Warn("wg-config: server config not set", "has_public_key", s.cfg.ServerPublicKey != "", "has_endpoint", s.cfg.ServerEndpoint != "", "allowed_ips_count", len(s.cfg.ServerAllowedIPs))
 		writeJSONError(w, http.StatusInternalServerError, "server config not set")
 		return
 	}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -37,7 +37,7 @@ func TestMonitor_RunCollectsProbes(t *testing.T) {
 			{
 				PublicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
 				VPNIP:     "127.0.0.1",
-				ProbePort: 51900,
+				ProbePort: 19999,
 				Name:      "peer-1",
 			},
 		},


### PR DESCRIPTION
## Summary

Production readiness foundations for vpnctl:

- **Structured logging**: all `log.Printf` replaced with `log/slog`. Configurable via `VPNCTL_LOG_LEVEL` (debug/info/warn/error) and `VPNCTL_LOG_FORMAT` (text/json) env vars
- **Version info**: `vpnctl version` shows version, commit hash, and build time. Injected via ldflags at build
- **Makefile**: `make build` (with version injection), `make test`, `make clean`, `make docker`
- **systemd**: `deploy/vpnctl-controller.service` and `deploy/vpnctl-node.service` with CAP_NET_ADMIN
- **Dockerfile**: multi-stage build, debian-slim runtime with wireguard-tools
- **.gitignore**: ignore binary and .db files
- **README**: installation (source, Docker, systemd) and logging docs

No breaking changes. All existing tests pass.

## Test plan
- [x] `make build && ./vpnctl version` shows git hash + timestamp
- [x] `make test` passes all packages
- [x] `VPNCTL_LOG_LEVEL=debug VPNCTL_LOG_FORMAT=json ./vpnctl node serve --config ...` outputs JSON logs
- [ ] systemd units have correct paths and capabilities