### PR TITLE
feat: mTLS authentication with bootstrap token enrollment

### DIFF
--- a/cmd/vpnctl/main.go
+++ b/cmd/vpnctl/main.go
@@ -19,6 +19,8 @@ import (
 	"syscall"
 	"time"
 
+	"crypto/tls"
+
 	"vpnctl/internal/addrutil"
 	"vpnctl/internal/agent"
 	"vpnctl/internal/api"
@@ -29,6 +31,7 @@ import (
 	"vpnctl/internal/model"
 	"vpnctl/internal/monitor"
 	"vpnctl/internal/peersource"
+	"vpnctl/internal/pki"
 	"vpnctl/internal/store"
 	"vpnctl/internal/stunutil"
 	"vpnctl/internal/wireguard"
@@ -155,6 +158,8 @@ func handleController(args []string) {
 		controllerInit(args[1:])
 	case "status":
 		controllerStatus(args[1:])
+	case "token":
+		controllerToken(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown controller subcommand %q\n", args[0])
 		os.Exit(2)
@@ -188,6 +193,17 @@ func controllerInit(args []string) {
 	if err != nil {
 		fatal(err)
 	}
+
+	if cfg.Controller.PKI != nil {
+		token, err := srv.InitPKI()
+		if err != nil {
+			fatal(err)
+		}
+		if token != "" {
+			fmt.Fprintf(os.Stdout, "bootstrap token: %s\n", token)
+		}
+	}
+
 	fatal(srv.ListenAndServe())
 }
 
@@ -241,6 +257,61 @@ func controllerStatus(args []string) {
 	}
 }
 
+func controllerToken(args []string) {
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, "controller token subcommand required (create|list|revoke)\n")
+		os.Exit(2)
+	}
+
+	sub := args[0]
+	fs := flag.NewFlagSet("controller token "+sub, flag.ExitOnError)
+	configPath := fs.String("config", "", "path to YAML config")
+	_ = fs.Parse(args[1:])
+
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		fatal(err)
+	}
+	if cfg.Controller == nil {
+		fatal(errors.New("controller config required"))
+	}
+	config.ApplyDefaults(&cfg)
+	if cfg.Controller.DataDir == "" {
+		fatal(errors.New("controller.data_dir is required"))
+	}
+
+	tokenPath := filepath.Join(cfg.Controller.DataDir, "pki", "bootstrap-tokens.json")
+	ts, err := pki.OpenTokenStore(tokenPath)
+	if err != nil {
+		fatal(err)
+	}
+
+	switch sub {
+	case "create":
+		token := ts.Create()
+		fmt.Fprintln(os.Stdout, token)
+	case "list":
+		tokens := ts.List()
+		if len(tokens) == 0 {
+			fmt.Fprintln(os.Stdout, "no active tokens")
+			return
+		}
+		for _, t := range tokens {
+			fmt.Fprintln(os.Stdout, t)
+		}
+	case "revoke":
+		remaining := fs.Args()
+		if len(remaining) == 0 {
+			fatal(errors.New("token value is required"))
+		}
+		ts.Revoke(remaining[0])
+		fmt.Fprintln(os.Stdout, "token revoked")
+	default:
+		fmt.Fprintf(os.Stderr, "unknown token subcommand %q\n", sub)
+		os.Exit(2)
+	}
+}
+
 func handleNode(args []string) {
 	if len(args) == 0 {
 		fmt.Fprint(os.Stderr, "node subcommand required\n")
@@ -273,6 +344,7 @@ func nodeJoin(args []string) {
 	vpnIP := fs.String("vpn-ip", "", "WireGuard VPN IP")
 	directMode := fs.String("direct", "", "direct mode: auto|off")
 	stunList := fs.String("stun", "", "comma-separated STUN servers")
+	token := fs.String("token", "", "bootstrap token for mTLS enrollment")
 	_ = fs.Parse(args)
 
 	cfg, err := loadConfig(*configPath)
@@ -288,6 +360,69 @@ func nodeJoin(args []string) {
 	if err := config.Validate(cfg); err != nil {
 		fatal(err)
 	}
+
+	// Token-based bootstrap flow: generate CSR, call /bootstrap, save certs.
+	if *token != "" && cfg.Node.Controller != "" {
+		if cfg.Node.Name == "" {
+			fatal(errors.New("node.name is required for bootstrap"))
+		}
+
+		csrPEM, keyPEM, err := pki.GenerateCSR(cfg.Node.Name)
+		if err != nil {
+			fatal(fmt.Errorf("generate CSR: %w", err))
+		}
+
+		// Use an insecure TLS client for bootstrap — we don't have the CA cert yet.
+		baseURL := normalizeBootstrapURL(cfg.Node.Controller)
+		insecureClient := api.NewTLSClient(baseURL, &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // bootstrap phase
+			MinVersion:         tls.VersionTLS13,
+		})
+
+		ctx := context.Background()
+		resp, err := insecureClient.Bootstrap(ctx, api.BootstrapRequest{
+			Token: *token,
+			Name:  cfg.Node.Name,
+			CSR:   string(csrPEM),
+		})
+		if err != nil {
+			fatal(fmt.Errorf("bootstrap: %w", err))
+		}
+
+		// Save certificates to pki_dir.
+		pkiDir := cfg.Node.PKIDir
+		if pkiDir == "" {
+			pkiDir = filepath.Join(filepath.Dir(*configPath), "pki")
+		}
+		if err := os.MkdirAll(pkiDir, 0o755); err != nil {
+			fatal(err)
+		}
+
+		if err := os.WriteFile(filepath.Join(pkiDir, "ca.crt"), []byte(resp.CACert), 0o644); err != nil {
+			fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkiDir, "client.key"), keyPEM, 0o600); err != nil {
+			fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkiDir, "client.crt"), []byte(resp.ClientCert), 0o644); err != nil {
+			fatal(err)
+		}
+
+		// Write pki_dir back to config.
+		cfg.Node.PKIDir = pkiDir
+		if cfg.Node.VPNIP == "" && resp.VPNIP != "" {
+			cfg.Node.VPNIP = resp.VPNIP
+		}
+		if *configPath != "" {
+			if err := config.Save(*configPath, cfg); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to save config: %v\n", err)
+			}
+		}
+
+		fmt.Fprintf(os.Stdout, "bootstrap ok node_id=%s vpn_ip=%s pki_dir=%s\n", resp.NodeID, resp.VPNIP, pkiDir)
+		return
+	}
+
 	if cfg.Node.WGPublicKey == "" {
 		fatal(errors.New("wg_public_key is required"))
 	}
@@ -1399,6 +1534,17 @@ func normalizeBaseURL(addr string) string {
 		return addr
 	}
 	return "http://" + addr
+}
+
+// normalizeBootstrapURL ensures the controller URL uses https for bootstrap.
+func normalizeBootstrapURL(addr string) string {
+	if strings.HasPrefix(addr, "https://") {
+		return addr
+	}
+	if strings.HasPrefix(addr, "http://") {
+		return "https://" + strings.TrimPrefix(addr, "http://")
+	}
+	return "https://" + addr
 }
 
 func selectPeer(peer string, candidates []api.PeerCandidate) (string, string) {

--- a/deploy/docker-compose.test.yaml
+++ b/deploy/docker-compose.test.yaml
@@ -1,0 +1,92 @@
+# docker-compose.test.yaml — mTLS bootstrap flow integration test
+#
+# Tests the full enrollment flow WITHOUT WireGuard (control plane only):
+#   1. Controller starts, generates CA + server cert + bootstrap token
+#   2. Nodes wait for token, then join via --token
+#   3. mTLS handshake verified
+#
+# Usage:
+#   docker compose -f deploy/docker-compose.test.yaml up --build
+#   docker compose -f deploy/docker-compose.test.yaml down -v
+
+services:
+  controller:
+    build: ..
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        # Start controller and capture bootstrap token from stdout
+        vpnctl controller init --config /etc/vpnctl/controller.yaml 2>&1 &
+        PID=$$!
+        # Wait for token file to be generated
+        while [ ! -f /var/lib/vpnctl/pki/bootstrap-tokens.json ]; do sleep 0.5; done
+        # Extract token and write to shared volume
+        TOKEN=$$(cat /var/lib/vpnctl/pki/bootstrap-tokens.json | head -1 | grep -o 'vpnctl-bootstrap-[a-f0-9]*')
+        echo "$$TOKEN" > /shared/bootstrap-token
+        echo "Bootstrap token written: $$TOKEN"
+        wait $$PID
+    volumes:
+      - shared-pki:/shared
+      - controller-data:/var/lib/vpnctl
+      - ./test-configs/controller.yaml:/etc/vpnctl/controller.yaml:ro
+    ports:
+      - "8443:8443"
+    healthcheck:
+      test: ["CMD", "sh", "-c", "test -f /shared/bootstrap-token"]
+      interval: 1s
+      timeout: 2s
+      retries: 30
+
+  node-a:
+    build: ..
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "Waiting for bootstrap token..."
+        while [ ! -f /shared/bootstrap-token ]; do sleep 1; done
+        TOKEN=$$(cat /shared/bootstrap-token)
+        echo "Joining with token: $$TOKEN"
+        vpnctl node join --config /etc/vpnctl/node.yaml --token "$$TOKEN"
+        echo "=== Node A: checking certificates ==="
+        ls -la /etc/vpnctl/pki/
+        echo "=== Node A: ca.crt ==="
+        openssl x509 -in /etc/vpnctl/pki/ca.crt -noout -subject 2>/dev/null && echo "CA cert OK" || echo "CA cert missing"
+        echo "=== Node A: client.crt ==="
+        openssl x509 -in /etc/vpnctl/pki/client.crt -noout -subject 2>/dev/null && echo "Client cert OK" || echo "Client cert missing"
+        echo "=== Node A: DONE ==="
+        sleep 3600
+    volumes:
+      - shared-pki:/shared
+      - node-a-pki:/etc/vpnctl/pki
+      - ./test-configs/node-a.yaml:/etc/vpnctl/node.yaml
+    depends_on:
+      controller:
+        condition: service_healthy
+
+  node-b:
+    build: ..
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "Waiting for bootstrap token..."
+        while [ ! -f /shared/bootstrap-token ]; do sleep 1; done
+        TOKEN=$$(cat /shared/bootstrap-token)
+        echo "Joining with token: $$TOKEN"
+        vpnctl node join --config /etc/vpnctl/node.yaml --token "$$TOKEN"
+        echo "=== Node B: checking certificates ==="
+        ls -la /etc/vpnctl/pki/
+        echo "=== Node B: DONE ==="
+        sleep 3600
+    volumes:
+      - shared-pki:/shared
+      - node-b-pki:/etc/vpnctl/pki
+      - ./test-configs/node-b.yaml:/etc/vpnctl/node.yaml
+    depends_on:
+      controller:
+        condition: service_healthy
+
+volumes:
+  shared-pki:
+  controller-data:
+  node-a-pki:
+  node-b-pki:

--- a/deploy/test-configs/controller.yaml
+++ b/deploy/test-configs/controller.yaml
@@ -1,0 +1,11 @@
+# Test controller config — mTLS enabled, no WireGuard
+controller:
+  listen: "0.0.0.0:8443"
+  data_dir: "/var/lib/vpnctl"
+  vpn_cidr: "10.7.0.0/24"
+  wg_apply: false
+  probe_port: 0
+  pki:
+    ca_expiry: "87600h"
+    server_expiry: "8760h"
+    client_expiry: "8760h"

--- a/deploy/test-configs/node-a.yaml
+++ b/deploy/test-configs/node-a.yaml
@@ -1,0 +1,6 @@
+# Test node-a config — joins controller via bootstrap token
+node:
+  name: "node-a"
+  controller: "controller:8443"
+  pki_dir: "/etc/vpnctl/pki"
+  wg_public_key: "test-pubkey-node-a"

--- a/deploy/test-configs/node-b.yaml
+++ b/deploy/test-configs/node-b.yaml
@@ -1,0 +1,6 @@
+# Test node-b config — joins controller via bootstrap token
+node:
+  name: "node-b"
+  controller: "controller:8443"
+  pki_dir: "/etc/vpnctl/pki"
+  wg_public_key: "test-pubkey-node-b"

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -6,6 +6,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -31,10 +32,30 @@ func NewClient(baseURL string) *Client {
 	}
 }
 
+// NewTLSClient creates a client with custom TLS configuration.
+func NewTLSClient(baseURL string, tlsConfig *tls.Config) *Client {
+	return &Client{
+		baseURL: baseURL,
+		http: &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		},
+	}
+}
+
 // Register registers a node and returns peer candidates.
 func (c *Client) Register(ctx context.Context, req RegisterRequest) (RegisterResponse, error) {
 	var resp RegisterResponse
 	if err := c.postJSON(ctx, "/register", req, &resp); err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// Bootstrap enrolls a node using a bootstrap token and CSR.
+func (c *Client) Bootstrap(ctx context.Context, req BootstrapRequest) (BootstrapResponse, error) {
+	var resp BootstrapResponse
+	if err := c.postJSON(ctx, "/bootstrap", req, &resp); err != nil {
 		return resp, err
 	}
 	return resp, nil

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -108,3 +108,18 @@ type FleetNodeHistory struct {
 type FleetHistoryResponse struct {
 	Nodes []FleetNodeHistory `json:"nodes"`
 }
+
+// BootstrapRequest is sent by a node during initial enrollment.
+type BootstrapRequest struct {
+	Token string `json:"token"`
+	Name  string `json:"name"`
+	CSR   string `json:"csr"` // PEM-encoded CSR
+}
+
+// BootstrapResponse returns the CA cert and signed client cert.
+type BootstrapResponse struct {
+	CACert     string `json:"ca_cert"`     // PEM
+	ClientCert string `json:"client_cert"` // PEM
+	NodeID     string `json:"node_id"`
+	VPNIP      string `json:"vpn_ip"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,15 @@ type ControllerConfig struct {
 	// either: requires recent success in either direction (symmetric injection, more permissive).
 	P2PReadyMode string `yaml:"p2p_ready_mode"`
 	ProbePort    int    `yaml:"probe_port"`
+	PKI          *PKIConfig `yaml:"pki,omitempty"`
+}
+
+// PKIConfig controls certificate generation for mTLS.
+type PKIConfig struct {
+	CAExpiry     string `yaml:"ca_expiry"`      // e.g. "87600h" (default 10 years)
+	ServerExpiry string `yaml:"server_expiry"`   // e.g. "8760h" (default 1 year)
+	ClientExpiry string `yaml:"client_expiry"`   // e.g. "8760h" (default 1 year)
+	KeyAlgorithm string `yaml:"key_algorithm"`   // e.g. "ecdsa-p256" (default)
 }
 
 // NodeConfig is used by the agent process running on a device.
@@ -108,6 +117,7 @@ type NodeConfig struct {
 	HealthCheckFailures    int    `yaml:"health_check_failures"`
 	HealthCheckTimeoutSec  int    `yaml:"health_check_timeout_sec"`
 	ServerProbePort        int    `yaml:"server_probe_port"`
+	PKIDir                 string `yaml:"pki_dir"` // directory for ca.crt, client.key, client.crt
 }
 
 // Load reads and parses a YAML config file.
@@ -232,6 +242,20 @@ func ApplyDefaults(cfg *Config) {
 		}
 		if cfg.Controller.ProbePort == 0 {
 			cfg.Controller.ProbePort = DefaultProbePort
+		}
+		if cfg.Controller.PKI != nil {
+			if cfg.Controller.PKI.CAExpiry == "" {
+				cfg.Controller.PKI.CAExpiry = "87600h"
+			}
+			if cfg.Controller.PKI.ServerExpiry == "" {
+				cfg.Controller.PKI.ServerExpiry = "8760h"
+			}
+			if cfg.Controller.PKI.ClientExpiry == "" {
+				cfg.Controller.PKI.ClientExpiry = "8760h"
+			}
+			if cfg.Controller.PKI.KeyAlgorithm == "" {
+				cfg.Controller.PKI.KeyAlgorithm = "ecdsa-p256"
+			}
 		}
 	}
 

--- a/internal/controller/server.go
+++ b/internal/controller/server.go
@@ -4,9 +4,11 @@
 package controller
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/netip"
 	"os"
@@ -19,6 +21,7 @@ import (
 	"vpnctl/internal/config"
 	"vpnctl/internal/direct"
 	"vpnctl/internal/metrics"
+	"vpnctl/internal/pki"
 	"vpnctl/internal/store"
 	"vpnctl/internal/wireguard"
 )
@@ -37,6 +40,8 @@ type Server struct {
 	// Used to gate P2P WireGuard /32 injection so relay doesn't get blackholed.
 	directOK       map[string]map[string]time.Time // node_id -> peer_id -> last success
 	probeResponder *direct.Responder
+	tokenStore     *pki.TokenStore
+	pkiDir         string
 }
 
 // NewServer constructs a controller server.
@@ -73,6 +78,84 @@ func NewServer(cfg config.ControllerConfig) (*Server, error) {
 	}, nil
 }
 
+// InitPKI initialises the PKI directory, generates the CA and server certificate
+// if they don't exist, opens the bootstrap token store, and creates an initial
+// token when the store is empty. The returned string is the bootstrap token if
+// one was freshly created (empty otherwise).
+func (s *Server) InitPKI() (string, error) {
+	if s.cfg.PKI == nil {
+		return "", fmt.Errorf("controller.pki config section is required")
+	}
+
+	pkiDir := filepath.Join(s.cfg.DataDir, "pki")
+	if err := os.MkdirAll(pkiDir, 0o755); err != nil {
+		return "", fmt.Errorf("create pki dir: %w", err)
+	}
+	s.pkiDir = pkiDir
+
+	caKeyPath := filepath.Join(pkiDir, "ca.key")
+	caCertPath := filepath.Join(pkiDir, "ca.crt")
+
+	// Generate CA if it doesn't exist.
+	if _, err := os.Stat(caCertPath); os.IsNotExist(err) {
+		caExpiry, err := time.ParseDuration(s.cfg.PKI.CAExpiry)
+		if err != nil {
+			return "", fmt.Errorf("parse ca_expiry: %w", err)
+		}
+		if err := pki.GenerateCA(caKeyPath, caCertPath, caExpiry); err != nil {
+			return "", fmt.Errorf("generate CA: %w", err)
+		}
+		slog.Info("generated CA certificate", "path", caCertPath)
+	}
+
+	serverKeyPath := filepath.Join(pkiDir, "server.key")
+	serverCertPath := filepath.Join(pkiDir, "server.crt")
+
+	// Generate server cert if it doesn't exist.
+	if _, err := os.Stat(serverCertPath); os.IsNotExist(err) {
+		serverExpiry, err := time.ParseDuration(s.cfg.PKI.ServerExpiry)
+		if err != nil {
+			return "", fmt.Errorf("parse server_expiry: %w", err)
+		}
+		sans := extractSANs(s.cfg.Listen)
+		if err := pki.GenerateServerCert(caCertPath, caKeyPath, serverKeyPath, serverCertPath, sans, serverExpiry); err != nil {
+			return "", fmt.Errorf("generate server cert: %w", err)
+		}
+		slog.Info("generated server certificate", "path", serverCertPath, "sans", sans)
+	}
+
+	// Open token store.
+	tokenPath := filepath.Join(pkiDir, "bootstrap-tokens.json")
+	ts, err := pki.OpenTokenStore(tokenPath)
+	if err != nil {
+		return "", fmt.Errorf("open token store: %w", err)
+	}
+	s.tokenStore = ts
+
+	// Create initial bootstrap token if store is empty.
+	var bootstrapToken string
+	if len(ts.List()) == 0 {
+		bootstrapToken = ts.Create()
+		slog.Info("created initial bootstrap token")
+	}
+
+	return bootstrapToken, nil
+}
+
+// extractSANs parses the host part of a listen address and returns suitable
+// SANs for the server certificate. If the host is empty, it adds "127.0.0.1"
+// and "localhost".
+func extractSANs(listen string) []string {
+	host, _, err := net.SplitHostPort(listen)
+	if err != nil {
+		host = listen
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		return []string{"127.0.0.1", "localhost"}
+	}
+	return []string{host}
+}
+
 // ListenAndServe runs the HTTP server.
 func (s *Server) ListenAndServe() error {
 	if s.cfg.ProbePort > 0 {
@@ -84,19 +167,38 @@ func (s *Server) ListenAndServe() error {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/register", s.handleRegister)
-	mux.HandleFunc("/candidates", s.handleCandidates)
-	mux.HandleFunc("/metrics", s.handleMetrics)
-	mux.HandleFunc("/nat-probe", s.handleNATProbe)
-	mux.HandleFunc("/direct-result", s.handleDirectResult)
-	mux.HandleFunc("/wg-config", s.handleWGConfig)
-	mux.HandleFunc("/fleet/status", s.handleFleetStatus)
-	mux.HandleFunc("/fleet/history", s.handleFleetHistory)
+	mux.HandleFunc("/bootstrap", s.handleBootstrap)
+	mux.HandleFunc("/register", s.requireClientCert(s.handleRegister))
+	mux.HandleFunc("/candidates", s.requireClientCert(s.handleCandidates))
+	mux.HandleFunc("/metrics", s.requireClientCert(s.handleMetrics))
+	mux.HandleFunc("/nat-probe", s.requireClientCert(s.handleNATProbe))
+	mux.HandleFunc("/direct-result", s.requireClientCert(s.handleDirectResult))
+	mux.HandleFunc("/wg-config", s.requireClientCert(s.handleWGConfig))
+	mux.HandleFunc("/fleet/status", s.requireClientCert(s.handleFleetStatus))
+	mux.HandleFunc("/fleet/history", s.requireClientCert(s.handleFleetHistory))
 
 	server := &http.Server{
 		Addr:              s.cfg.Listen,
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	if s.cfg.PKI != nil && s.pkiDir != "" {
+		tlsCfg, err := pki.ServerTLSConfig(
+			filepath.Join(s.pkiDir, "ca.crt"),
+			filepath.Join(s.pkiDir, "server.crt"),
+			filepath.Join(s.pkiDir, "server.key"),
+		)
+		if err != nil {
+			return fmt.Errorf("server TLS config: %w", err)
+		}
+		// Allow /bootstrap to work without a client cert. The
+		// requireClientCert middleware enforces client certs for all
+		// other endpoints.
+		tlsCfg.ClientAuth = tls.VerifyClientCertIfGiven
+		server.TLSConfig = tlsCfg
+		slog.Info("controller listening (mTLS)", "addr", s.cfg.Listen)
+		return server.ListenAndServeTLS("", "")
 	}
 
 	slog.Info("controller listening", "addr", s.cfg.Listen)
@@ -120,6 +222,149 @@ func (s *Server) StopProbeResponder() {
 		_ = s.probeResponder.Close()
 		s.probeResponder = nil
 	}
+}
+
+// requireClientCert wraps a handler and rejects requests without a valid
+// client certificate when mTLS is configured.
+func (s *Server) requireClientCert(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.cfg.PKI != nil && s.pkiDir != "" {
+			if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+				http.Error(w, "client certificate required", http.StatusUnauthorized)
+				return
+			}
+		}
+		next(w, r)
+	}
+}
+
+// handleBootstrap handles POST /bootstrap for node enrollment via token + CSR.
+func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var req api.BootstrapRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Token == "" || req.Name == "" || req.CSR == "" {
+		writeJSONError(w, http.StatusBadRequest, "token, name, and csr are required")
+		return
+	}
+
+	// Validate token.
+	if s.tokenStore == nil || !s.tokenStore.Validate(req.Token) {
+		writeJSONError(w, http.StatusUnauthorized, "invalid bootstrap token")
+		return
+	}
+
+	// Load CA and sign the CSR.
+	caKeyPath := filepath.Join(s.pkiDir, "ca.key")
+	caCertPath := filepath.Join(s.pkiDir, "ca.crt")
+	caCert, caKey, err := pki.LoadCA(caKeyPath, caCertPath)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to load CA: "+err.Error())
+		return
+	}
+
+	clientExpiry, err := time.ParseDuration(s.cfg.PKI.ClientExpiry)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "invalid client_expiry: "+err.Error())
+		return
+	}
+
+	signedCert, err := pki.SignCSR(caCert, caKey, []byte(req.CSR), clientExpiry)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to sign CSR: "+err.Error())
+		return
+	}
+
+	// Read CA cert PEM for the response.
+	caCertPEM, err := os.ReadFile(caCertPath)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to read CA cert: "+err.Error())
+		return
+	}
+
+	// Register the node in the registry (reuse registration logic).
+	nodeID, vpnIP := s.registerNodeLocked(req.Name, "" /* pubKey */, "" /* vpnIP */, "" /* endpoint */, 0 /* probePort */, "" /* publicAddr */, "" /* natType */)
+
+	writeJSON(w, http.StatusOK, api.BootstrapResponse{
+		CACert:     string(caCertPEM),
+		ClientCert: string(signedCert),
+		NodeID:     nodeID,
+		VPNIP:      vpnIP,
+	})
+}
+
+// registerNodeLocked registers or updates a node in the registry, allocating a
+// VPN IP when one is not provided. It returns (nodeID, vpnIP). This method is
+// shared by handleRegister and handleBootstrap.
+func (s *Server) registerNodeLocked(name, pubKey, vpnIP, endpoint string, probePort int, publicAddr, natType string) (string, string) {
+	now := time.Now().UTC()
+	assignedVPNIP := vpnIP
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if assignedVPNIP == "" {
+		var err error
+		assignedVPNIP, err = allocateVPNIP(s.cfg.VPNCIDR, s.reg)
+		if err != nil {
+			return name, ""
+		}
+	}
+
+	var nodeID string
+	updated := false
+	for i := range s.reg.Nodes {
+		if s.reg.Nodes[i].Name == name {
+			if s.reg.Nodes[i].ID == "" {
+				s.reg.Nodes[i].ID = name
+			}
+			if pubKey != "" {
+				s.reg.Nodes[i].PubKey = pubKey
+			}
+			s.reg.Nodes[i].VPNIP = assignedVPNIP
+			if endpoint != "" {
+				s.reg.Nodes[i].Endpoint = endpoint
+			}
+			s.reg.Nodes[i].ProbePort = probePort
+			if publicAddr != "" {
+				s.reg.Nodes[i].PublicAddr = publicAddr
+			}
+			if natType != "" {
+				s.reg.Nodes[i].NATType = natType
+			}
+			s.reg.Nodes[i].LastSeenAt = now
+			s.reg.Nodes[i].Status = "online"
+			nodeID = s.reg.Nodes[i].ID
+			updated = true
+			break
+		}
+	}
+
+	if !updated {
+		nodeID = name
+		s.reg.Nodes = append(s.reg.Nodes, store.NodeInfo{
+			ID:         nodeID,
+			Name:       name,
+			PubKey:     pubKey,
+			VPNIP:      assignedVPNIP,
+			Endpoint:   endpoint,
+			ProbePort:  probePort,
+			PublicAddr: publicAddr,
+			NATType:    natType,
+			LastSeenAt: now,
+			Status:     "online",
+		})
+	}
+
+	_ = store.SaveRegistry(s.regPath, s.reg)
+	return nodeID, assignedVPNIP
 }
 
 func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {

--- a/internal/pki/bootstrap.go
+++ b/internal/pki/bootstrap.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Jonghyeok Kang
+// SPDX-License-Identifier: Apache-2.0
+
+package pki
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+// GenerateToken returns a bootstrap token with format "vpnctl-bootstrap-" + 16 random hex bytes.
+func GenerateToken() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return "vpnctl-bootstrap-" + hex.EncodeToString(b)
+}
+
+// TokenStore manages active bootstrap tokens with persistence.
+type TokenStore struct {
+	mu     sync.Mutex
+	path   string
+	tokens map[string]bool
+}
+
+// OpenTokenStore loads tokens from file or creates an empty store if file doesn't exist.
+func OpenTokenStore(path string) (*TokenStore, error) {
+	store := &TokenStore{
+		path:   path,
+		tokens: make(map[string]bool),
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return store, nil
+		}
+		return nil, err
+	}
+
+	var tokenList []string
+	if err := json.Unmarshal(data, &tokenList); err != nil {
+		return nil, err
+	}
+
+	for _, token := range tokenList {
+		store.tokens[token] = true
+	}
+
+	return store, nil
+}
+
+// Create generates a token, adds it to the active set, saves to file, and returns the token.
+func (ts *TokenStore) Create() string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	token := GenerateToken()
+	ts.tokens[token] = true
+	_ = ts.save()
+	return token
+}
+
+// Validate checks if a token is in the active set.
+func (ts *TokenStore) Validate(token string) bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	return ts.tokens[token]
+}
+
+// Revoke removes a token from the active set and saves.
+func (ts *TokenStore) Revoke(token string) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	delete(ts.tokens, token)
+	_ = ts.save()
+}
+
+// List returns all active tokens.
+func (ts *TokenStore) List() []string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	tokens := make([]string, 0, len(ts.tokens))
+	for token := range ts.tokens {
+		tokens = append(tokens, token)
+	}
+	return tokens
+}
+
+// save marshals active tokens as JSON array and writes to file with mode 0600.
+func (ts *TokenStore) save() error {
+	tokenList := make([]string, 0, len(ts.tokens))
+	for token := range ts.tokens {
+		tokenList = append(tokenList, token)
+	}
+
+	data, err := json.Marshal(tokenList)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(ts.path, data, 0o600)
+}

--- a/internal/pki/bootstrap_test.go
+++ b/internal/pki/bootstrap_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Jonghyeok Kang
+// SPDX-License-Identifier: Apache-2.0
+
+package pki_test
+
+import (
+	"os"
+	"testing"
+
+	"vpnctl/internal/pki"
+)
+
+func TestGenerateToken(t *testing.T) {
+	token := pki.GenerateToken()
+
+	if len(token) < 20 {
+		t.Errorf("expected token length >= 20, got %d", len(token))
+	}
+
+	expectedPrefix := "vpnctl-bootstrap-"
+	if len(token) < len(expectedPrefix) || token[:len(expectedPrefix)] != expectedPrefix {
+		t.Errorf("expected token to start with %q, got %q", expectedPrefix, token)
+	}
+}
+
+func TestTokenStore_CreateAndValidate(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/tokens.json"
+
+	store, err := pki.OpenTokenStore(path)
+	if err != nil {
+		t.Fatalf("OpenTokenStore failed: %v", err)
+	}
+
+	token := store.Create()
+
+	if !store.Validate(token) {
+		t.Error("expected Validate(token) to return true")
+	}
+
+	if store.Validate("bogus-token") {
+		t.Error("expected Validate(bogus-token) to return false")
+	}
+}
+
+func TestTokenStore_Revoke(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/tokens.json"
+
+	store, err := pki.OpenTokenStore(path)
+	if err != nil {
+		t.Fatalf("OpenTokenStore failed: %v", err)
+	}
+
+	token := store.Create()
+
+	if !store.Validate(token) {
+		t.Error("expected Validate(token) to return true before revoke")
+	}
+
+	store.Revoke(token)
+
+	if store.Validate(token) {
+		t.Error("expected Validate(token) to return false after revoke")
+	}
+}
+
+func TestTokenStore_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/tokens.json"
+
+	store1, err := pki.OpenTokenStore(path)
+	if err != nil {
+		t.Fatalf("OpenTokenStore failed: %v", err)
+	}
+
+	token := store1.Create()
+
+	if !store1.Validate(token) {
+		t.Error("expected Validate(token) to return true in store1")
+	}
+
+	store2, err := pki.OpenTokenStore(path)
+	if err != nil {
+		t.Fatalf("OpenTokenStore (store2) failed: %v", err)
+	}
+
+	if !store2.Validate(token) {
+		t.Error("expected Validate(token) to return true in store2 (loaded from file)")
+	}
+
+	stat, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat failed: %v", err)
+	}
+
+	mode := stat.Mode() & 0o777
+	if mode != 0o600 {
+		t.Errorf("expected file mode 0600, got %o", mode)
+	}
+}
+
+func TestTokenStore_List(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/tokens.json"
+
+	store, err := pki.OpenTokenStore(path)
+	if err != nil {
+		t.Fatalf("OpenTokenStore failed: %v", err)
+	}
+
+	token1 := store.Create()
+	token2 := store.Create()
+
+	tokens := store.List()
+
+	if len(tokens) != 2 {
+		t.Errorf("expected 2 tokens, got %d", len(tokens))
+	}
+
+	tokenMap := make(map[string]bool)
+	for _, token := range tokens {
+		tokenMap[token] = true
+	}
+
+	if !tokenMap[token1] {
+		t.Error("expected token1 in list")
+	}
+	if !tokenMap[token2] {
+		t.Error("expected token2 in list")
+	}
+}

--- a/internal/pki/ca.go
+++ b/internal/pki/ca.go
@@ -1,0 +1,240 @@
+// Copyright 2025 Jonghyeok Kang
+// SPDX-License-Identifier: Apache-2.0
+
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"time"
+)
+
+// randomSerial generates a cryptographically random certificate serial number.
+func randomSerial() (*big.Int, error) {
+	max := new(big.Int).Lsh(big.NewInt(1), 128)
+	return rand.Int(rand.Reader, max)
+}
+
+// writeKeyPEM writes an ECDSA private key as PEM to path with mode 0600.
+func writeKeyPEM(path string, key *ecdsa.PrivateKey) error {
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return err
+	}
+	block := &pem.Block{Type: "EC PRIVATE KEY", Bytes: der}
+	return os.WriteFile(path, pem.EncodeToMemory(block), 0600)
+}
+
+// writeCertPEM writes a DER-encoded certificate as PEM to path with mode 0644.
+func writeCertPEM(path string, derBytes []byte) error {
+	block := &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}
+	return os.WriteFile(path, pem.EncodeToMemory(block), 0644)
+}
+
+// GenerateCA generates an ECDSA P-256 CA keypair and self-signed certificate,
+// writing the key (0600) and cert (0644) PEM files to keyPath and certPath.
+func GenerateCA(keyPath, certPath string, expiry time.Duration) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	serial, err := randomSerial()
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "vpnctl-ca",
+		},
+		NotBefore:             now,
+		NotAfter:              now.Add(expiry),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return err
+	}
+
+	if err := writeKeyPEM(keyPath, key); err != nil {
+		return err
+	}
+	return writeCertPEM(certPath, der)
+}
+
+// LoadCA reads and parses the CA certificate and private key from PEM files.
+func LoadCA(keyPath, certPath string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	certPEMData, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	block, _ := pem.Decode(certPEMData)
+	if block == nil {
+		return nil, nil, &pemError{path: certPath}
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyPEMData, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyBlock, _ := pem.Decode(keyPEMData)
+	if keyBlock == nil {
+		return nil, nil, &pemError{path: keyPath}
+	}
+	key, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, key, nil
+}
+
+// pemError is returned when PEM decoding fails.
+type pemError struct {
+	path string
+}
+
+func (e *pemError) Error() string {
+	return "pki: failed to decode PEM from " + e.path
+}
+
+// GenerateServerCert generates an ECDSA P-256 server certificate signed by the
+// given CA. SANs that parse as IP addresses are added to IPAddresses; others
+// are added to DNSNames. The key (0600) and cert (0644) PEM files are written
+// to keyPath and certPath.
+func GenerateServerCert(ca, caKey, keyPath, certPath string, sans []string, expiry time.Duration) error {
+	caCert, caPrivKey, err := LoadCA(caKey, ca)
+	if err != nil {
+		return err
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	serial, err := randomSerial()
+	if err != nil {
+		return err
+	}
+
+	var ipAddresses []net.IP
+	var dnsNames []string
+	for _, san := range sans {
+		if ip := net.ParseIP(san); ip != nil {
+			ipAddresses = append(ipAddresses, ip)
+		} else {
+			dnsNames = append(dnsNames, san)
+		}
+	}
+
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "vpnctl-controller",
+		},
+		NotBefore:    now,
+		NotAfter:     now.Add(expiry),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  ipAddresses,
+		DNSNames:     dnsNames,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caPrivKey)
+	if err != nil {
+		return err
+	}
+
+	if err := writeKeyPEM(keyPath, key); err != nil {
+		return err
+	}
+	return writeCertPEM(certPath, der)
+}
+
+// GenerateCSR generates an ECDSA P-256 keypair and a Certificate Signing
+// Request with the given Common Name. It returns the PEM-encoded CSR and key.
+func GenerateCSR(cn string) (csrPEM, keyPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tmpl := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName: cn,
+		},
+	}
+
+	der, err := x509.CreateCertificateRequest(rand.Reader, tmpl, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	csrPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return csrPEM, keyPEM, nil
+}
+
+// SignCSR parses and verifies the PEM-encoded CSR, then signs it with the CA,
+// returning a PEM-encoded client certificate with ExtKeyUsage=ClientAuth.
+func SignCSR(ca *x509.Certificate, caKey *ecdsa.PrivateKey, csrPEM []byte, expiry time.Duration) ([]byte, error) {
+	block, _ := pem.Decode(csrPEM)
+	if block == nil {
+		return nil, &pemError{path: "<csr>"}
+	}
+
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	if err := csr.CheckSignature(); err != nil {
+		return nil, err
+	}
+
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      csr.Subject,
+		NotBefore:    now,
+		NotAfter:     now.Add(expiry),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, csr.PublicKey, caKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), nil
+}

--- a/internal/pki/ca_test.go
+++ b/internal/pki/ca_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Jonghyeok Kang
+// SPDX-License-Identifier: Apache-2.0
+
+package pki_test
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"vpnctl/internal/pki"
+)
+
+func TestGenerateCA(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := dir + "/ca.key"
+	certPath := dir + "/ca.crt"
+
+	if err := pki.GenerateCA(keyPath, certPath, 24*time.Hour); err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	cert, _, err := pki.LoadCA(keyPath, certPath)
+	if err != nil {
+		t.Fatalf("LoadCA failed: %v", err)
+	}
+
+	if !cert.IsCA {
+		t.Error("expected IsCA=true")
+	}
+	if cert.Subject.CommonName != "vpnctl-ca" {
+		t.Errorf("expected CN=vpnctl-ca, got %s", cert.Subject.CommonName)
+	}
+}
+
+func TestSignServerCert(t *testing.T) {
+	dir := t.TempDir()
+	caKeyPath := dir + "/ca.key"
+	caCertPath := dir + "/ca.crt"
+
+	if err := pki.GenerateCA(caKeyPath, caCertPath, 24*time.Hour); err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	srvKeyPath := dir + "/server.key"
+	srvCertPath := dir + "/server.crt"
+	sans := []string{"127.0.0.1", "0.0.0.0"}
+
+	err := pki.GenerateServerCert(caCertPath, caKeyPath, srvKeyPath, srvCertPath, sans, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateServerCert failed: %v", err)
+	}
+
+	cert, _, err := pki.LoadCA(srvKeyPath, srvCertPath)
+	if err != nil {
+		t.Fatalf("LoadCA (server cert) failed: %v", err)
+	}
+
+	if cert.Subject.CommonName != "vpnctl-controller" {
+		t.Errorf("expected CN=vpnctl-controller, got %s", cert.Subject.CommonName)
+	}
+
+	ipSet := make(map[string]bool)
+	for _, ip := range cert.IPAddresses {
+		ipSet[ip.String()] = true
+	}
+	for _, san := range sans {
+		if !ipSet[san] {
+			t.Errorf("expected IP SAN %s not found in cert", san)
+		}
+	}
+}
+
+func TestSignCSR(t *testing.T) {
+	dir := t.TempDir()
+	caKeyPath := dir + "/ca.key"
+	caCertPath := dir + "/ca.crt"
+
+	if err := pki.GenerateCA(caKeyPath, caCertPath, 24*time.Hour); err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	caCert, caKey, err := pki.LoadCA(caKeyPath, caCertPath)
+	if err != nil {
+		t.Fatalf("LoadCA failed: %v", err)
+	}
+
+	csrPEM, _, err := pki.GenerateCSR("test-node")
+	if err != nil {
+		t.Fatalf("GenerateCSR failed: %v", err)
+	}
+
+	certPEM, err := pki.SignCSR(caCert, caKey, csrPEM, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("SignCSR failed: %v", err)
+	}
+
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("failed to decode cert PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParseCertificate failed: %v", err)
+	}
+
+	if cert.Subject.CommonName != "test-node" {
+		t.Errorf("expected CN=test-node, got %s", cert.Subject.CommonName)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	_, err = cert.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	if err != nil {
+		t.Errorf("cert verification against CA pool failed: %v", err)
+	}
+}

--- a/internal/pki/tls.go
+++ b/internal/pki/tls.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Jonghyeok Kang
+// SPDX-License-Identifier: Apache-2.0
+
+package pki
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+)
+
+// ServerTLSConfig builds a *tls.Config for a mutual-TLS server.
+// It loads the CA certificate into ClientCAs, loads the server certificate and
+// key, requires and verifies a client certificate, and enforces TLS 1.3.
+func ServerTLSConfig(caCertPath, serverCertPath, serverKeyPath string) (*tls.Config, error) {
+	caPEM, err := os.ReadFile(caCertPath)
+	if err != nil {
+		return nil, err
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caPEM) {
+		return nil, &pemError{path: caCertPath}
+	}
+
+	cert, err := tls.LoadX509KeyPair(serverCertPath, serverKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		ClientCAs:    caPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+	}, nil
+}
+
+// ClientTLSConfig builds a *tls.Config for a mutual-TLS client.
+// It loads the CA certificate into RootCAs.  If clientCertPath and
+// clientKeyPath are both non-empty, the client certificate and key are loaded
+// for mTLS; otherwise only the CA pool is configured (bootstrap phase).
+// TLS 1.3 is enforced.
+func ClientTLSConfig(caCertPath, clientCertPath, clientKeyPath string) (*tls.Config, error) {
+	caPEM, err := os.ReadFile(caCertPath)
+	if err != nil {
+		return nil, err
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caPEM) {
+		return nil, &pemError{path: caCertPath}
+	}
+
+	cfg := &tls.Config{
+		RootCAs:    caPool,
+		MinVersion: tls.VersionTLS13,
+	}
+
+	if clientCertPath != "" && clientKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+
+	return cfg, nil
+}

--- a/internal/pki/tls_test.go
+++ b/internal/pki/tls_test.go
@@ -1,0 +1,131 @@
+// Copyright 2025 Jonghyeok Kang
+// SPDX-License-Identifier: Apache-2.0
+
+package pki_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"vpnctl/internal/pki"
+)
+
+// setupTestPKI creates a CA, server cert, and client cert in a temp dir.
+// Returns paths to the CA cert, server cert/key, client cert/key.
+func setupTestPKI(t *testing.T) (caCertPath, srvCertPath, srvKeyPath, clientCertPath, clientKeyPath string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKeyPath := dir + "/ca.key"
+	caCertPath = dir + "/ca.crt"
+
+	if err := pki.GenerateCA(caKeyPath, caCertPath, 24*time.Hour); err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	srvKeyPath = dir + "/server.key"
+	srvCertPath = dir + "/server.crt"
+	if err := pki.GenerateServerCert(caCertPath, caKeyPath, srvKeyPath, srvCertPath, []string{"127.0.0.1"}, 24*time.Hour); err != nil {
+		t.Fatalf("GenerateServerCert failed: %v", err)
+	}
+
+	caCert, caKey, err := pki.LoadCA(caKeyPath, caCertPath)
+	if err != nil {
+		t.Fatalf("LoadCA failed: %v", err)
+	}
+
+	csrPEM, keyPEM, err := pki.GenerateCSR("test-client")
+	if err != nil {
+		t.Fatalf("GenerateCSR failed: %v", err)
+	}
+
+	certPEM, err := pki.SignCSR(caCert, caKey, csrPEM, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("SignCSR failed: %v", err)
+	}
+
+	clientCertPath = dir + "/client.crt"
+	clientKeyPath = dir + "/client.key"
+
+	if err := os.WriteFile(clientCertPath, certPEM, 0644); err != nil {
+		t.Fatalf("WriteFile client cert failed: %v", err)
+	}
+	if err := os.WriteFile(clientKeyPath, keyPEM, 0600); err != nil {
+		t.Fatalf("WriteFile client key failed: %v", err)
+	}
+
+	return caCertPath, srvCertPath, srvKeyPath, clientCertPath, clientKeyPath
+}
+
+func TestMTLSHandshake(t *testing.T) {
+	caCertPath, srvCertPath, srvKeyPath, clientCertPath, clientKeyPath := setupTestPKI(t)
+
+	serverTLS, err := pki.ServerTLSConfig(caCertPath, srvCertPath, srvKeyPath)
+	if err != nil {
+		t.Fatalf("ServerTLSConfig failed: %v", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	srv := httptest.NewUnstartedServer(handler)
+	srv.TLS = serverTLS
+	srv.StartTLS()
+	defer srv.Close()
+
+	clientTLS, err := pki.ClientTLSConfig(caCertPath, clientCertPath, clientKeyPath)
+	if err != nil {
+		t.Fatalf("ClientTLSConfig failed: %v", err)
+	}
+
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: clientTLS}}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	if string(body) != "ok" {
+		t.Errorf("expected body 'ok', got %q", string(body))
+	}
+}
+
+func TestMTLS_RejectsNoClientCert(t *testing.T) {
+	caCertPath, srvCertPath, srvKeyPath, _, _ := setupTestPKI(t)
+
+	serverTLS, err := pki.ServerTLSConfig(caCertPath, srvCertPath, srvKeyPath)
+	if err != nil {
+		t.Fatalf("ServerTLSConfig failed: %v", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	srv := httptest.NewUnstartedServer(handler)
+	srv.TLS = serverTLS
+	srv.StartTLS()
+	defer srv.Close()
+
+	// ClientTLSConfig with empty cert/key paths — CA only, no client cert.
+	clientTLS, err := pki.ClientTLSConfig(caCertPath, "", "")
+	if err != nil {
+		t.Fatalf("ClientTLSConfig (CA-only) failed: %v", err)
+	}
+
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: clientTLS}}
+	_, err = client.Get(srv.URL)
+	if err == nil {
+		t.Fatal("expected TLS handshake error when no client cert is presented, but got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds mTLS authentication to the controller API, inspired by kubeadm's bootstrap token flow.

### How it works

1. **Controller init** (with `pki:` config section): generates CA, server cert, and bootstrap token
2. **Node join --token**: sends CSR to `/bootstrap`, receives signed client cert + CA cert
3. **All subsequent API calls**: mTLS required (client cert verified against CA)
4. **Backward compatible**: without `pki:` config, existing HTTP behavior is unchanged

### New package: `internal/pki/`
- `ca.go` — CA generation, certificate signing, CSR handling (ECDSA P-256)
- `bootstrap.go` — token generation, validation, revocation, file persistence
- `tls.go` — ServerTLSConfig / ClientTLSConfig helpers

### New CLI commands
```
vpnctl controller token create --config <path>   # generate new bootstrap token
vpnctl controller token list --config <path>      # list active tokens
vpnctl controller token revoke <token> --config <path>  # revoke token
vpnctl node join --config <path> --token <token>  # enroll with bootstrap token
```

### Config additions
```yaml
controller:
  pki:
    ca_expiry: "87600h"      # 10 years default
    server_expiry: "8760h"   # 1 year default
    client_expiry: "8760h"   # 1 year default

node:
  pki_dir: "/etc/vpnctl/pki"
```

### Security model
- `/bootstrap` endpoint: token auth only (no mTLS — node doesn't have cert yet)
- All other endpoints: mTLS required when PKI is configured
- Bootstrap uses `InsecureSkipVerify` for initial contact (CA cert unknown), receives CA cert in response
- TLS 1.3 minimum

## Test plan
- [ ] `make test` passes (13 packages, including 10 new pki tests)
- [ ] `make build` clean
- [ ] Controller init with `pki:` section generates CA + server cert + token
- [ ] Node join with `--token` receives client cert and saves to pki_dir
- [ ] Existing commands without `pki:` config work unchanged (backward compatible)